### PR TITLE
Fix duplicate update call

### DIFF
--- a/index.html
+++ b/index.html
@@ -201,7 +201,6 @@ document.addEventListener("DOMContentLoaded", () => {
           // const stored = localStorage.getItem(id);
           el.addEventListener("input", () => {
             actualizarCampos();
-            actualizarCampos();
           });
         }
       });


### PR DESCRIPTION
## Summary
- remove redundant call to `actualizarCampos` when handling input events

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `true`


------
https://chatgpt.com/codex/tasks/task_b_685a338facac832385315f05318cca10