### PR TITLE
Remove certificate background image

### DIFF
--- a/css/certificate.css
+++ b/css/certificate.css
@@ -14,7 +14,8 @@
   width: 1800px;
   height: 1273px;
   position: relative;
-  background-image: url('https://i.imgur.com/qYdFFAB.png');
+  background-color: #ffffff;
+  background-image: none;
   background-size: 100% 100%;
 }
 .text-field {


### PR DESCRIPTION
## Summary
- remove the background image from the certificate canvas to eliminate the embedded logos
- use a plain white background in its place

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_6900d38294c48323b54b70951846c2d6